### PR TITLE
Adding textComponent prop to allow own TextInput Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ selectCountry(country){
 render(){
     return(
         <View style={styles.container}>
-            <PhoneInput 
-                ref='phone' 
+            <PhoneInput
+                ref='phone'
                 onPressFlag={this.onPressFlag}
             />
 
@@ -84,8 +84,8 @@ selectCountry(country){
 render(){
     return(
         <View style={styles.container}>
-            <PhoneInput 
-                ref='phone' 
+            <PhoneInput
+                ref='phone'
                 onPressFlag={this.onPressFlag}
             />
 
@@ -113,6 +113,7 @@ render(){
 | flagStyle | object | null | custom styles for flag image eg. {{width: 50, height: 30, borderWidth:0}} |
 | textStyle | object | null | custom styles for phone number text input eg. {{fontSize: 14}} |
 | textProps | object | null | properties for phone number text input eg. {{placeholder: 'Telephone number'}} |
+| textComponent | function | TextField | the input component to use |
 | offset | int | 10 | distance between flag and phone number |
 | pickerButtonColor | string | '#007AFF' | set button color of country picker |
 | pickerBackgroundColor | string | 'white' | set background color of country picker |

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ export default class PhoneInput extends Component {
             this.updateFlagAndFormatNumber(nextProps.value)
         }
     }
-    
+
     componentWillMount(){
         if(this.props.value)
             this.updateFlagAndFormatNumber(this.props.value)
@@ -56,7 +56,7 @@ export default class PhoneInput extends Component {
         this.setState({iso2, formattedNumber: phoneNumber}, actionAfterSetState)
     }
 
-    onChangePhoneNumber(number){      
+    onChangePhoneNumber(number){
         var actionAfterSetState = this.props.onChangePhoneNumber?() => {this.props.onChangePhoneNumber(number)}:null
         this.updateFlagAndFormatNumber(number, actionAfterSetState)
     }
@@ -117,18 +117,18 @@ export default class PhoneInput extends Component {
     }
 
     render(){
-        
+        const TextComponent = this.props.textComponent || TextInput;
         return (
             <View style={[styles.container, this.props.style]}>
                 <TouchableWithoutFeedback onPress={this.onPressFlag}>
-                    <Image source={Flags.get(this.state.iso2)} 
-                        resizeMode='stretch' 
+                    <Image source={Flags.get(this.state.iso2)}
+                        resizeMode='stretch'
                         style={[styles.flag, this.props.flagStyle]}
                         onPress={this.onPressFlag}
                     />
                 </TouchableWithoutFeedback>
                 <View style={{flex:1, marginLeft:this.props.offset || 10}}>
-                    <TextInput 
+                    <TextComponent
                             autoCorrect={false}
                             style={[styles.text, this.props.textStyle]}
                             onChangeText={(text) => this.onChangePhoneNumber(text)}
@@ -154,12 +154,12 @@ export default class PhoneInput extends Component {
                     itemStyle={this.props.pickerItemStyle}
                 />
             </View>
-            
         )
     }
 }
 
 PhoneInput.propTypes = {
+  textComponent: PropTypes.func,
   initialCountry: PropTypes.string,
   onChangePhoneNumber: PropTypes.func,
   value: PropTypes.string,


### PR DESCRIPTION
Hey hey,

I really like your work - thanks for it!

As I'm using a logic-including, pre-styled text input Component for all my forms, I'm in need of a way to pass in the TextField to use. Done! 😄 

* Added the `textComponent` prop, if not set, the original TextField is used.

Thanks and cheers 🍻 