### PR TITLE
Remove warning message propTypes from react@16

### DIFF
--- a/examples/CustomPicker/ModalPickerImage/index.js
+++ b/examples/CustomPicker/ModalPickerImage/index.js
@@ -1,9 +1,7 @@
 'use strict';
 
-import React,{
-    PropTypes
-} from 'react';
-
+import React from 'react';
+import PropTypes from 'prop-types';
 import {
     View,
     StyleSheet,
@@ -115,7 +113,7 @@ export default class ModalPicker extends BaseComponent {
             <TouchableOpacity key={option.key} onPress={()=>this.onChange(option)}>
                 <View style={[styles.optionStyle, this.props.optionStyle, {flex:1, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center'}]}>
                     <View style={{flex:0.15}}>
-                      <Image source={option.image} resizeMode='stretch' style={{width: 30, height: 16}}/>  
+                      <Image source={option.image} resizeMode='stretch' style={{width: 30, height: 16}}/>
                     </View>
                     <View style={{flex:0.7, alignItems: 'center'}}>
                       <Text style={[styles.optionTextStyle,this.props.optionTextStyle, {color: '#434343', fontSize: 14}]}>{option.label}</Text>

--- a/lib/countryPicker.js
+++ b/lib/countryPicker.js
@@ -1,8 +1,4 @@
-import React, {
-  Component,
-  PropTypes,
-} from 'react'
-
+import React, { Component } from 'react'
 import {
   StyleSheet,
   Text,
@@ -12,6 +8,7 @@ import {
   Picker,
   Dimensions,
 } from 'react-native'
+import PropTypes from 'prop-types';
 
 import Country from './country'
 import styles from './styles'

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
-import React, { Component,  PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   AppRegistry,
   StyleSheet,
@@ -8,6 +9,7 @@ import {
   TouchableWithoutFeedback,
   View
 } from 'react-native';
+
 
 import Flags from './resources/flags'
 import PhoneNumber from './phoneNumber'
@@ -137,7 +139,7 @@ export default class PhoneInput extends Component {
         return (
             <View style={[styles.container, this.props.style]}>
                 <TouchableWithoutFeedback onPress={this.onPressFlag}>
-                    <Image source={Flags.get(this.state.iso2)}                        
+                    <Image source={Flags.get(this.state.iso2)}
                         style={[styles.flag, this.props.flagStyle]}
                         onPress={this.onPressFlag}
                     />

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "android"
   ],
   "dependencies": {
+    "google-libphonenumber": "^2.0.9",
     "lodash": "^4.17.4",
-    "google-libphonenumber": "^2.0.9"
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
     "react-native": ">= 0.25"


### PR DESCRIPTION
Use `propTypes` with react@16 is deprecated.