### PR TITLE
Added landscape orientation support

### DIFF
--- a/lib/countryPicker.js
+++ b/lib/countryPicker.js
@@ -8,6 +8,7 @@ import styles from './styles';
 const PickerItem = Picker.Item;
 
 const propTypes = {
+  supportedOrientations: PropTypes.string,
   buttonColor: PropTypes.string,
   labels: PropTypes.array,
   confirmText: PropTypes.string,
@@ -80,6 +81,7 @@ export default class CountryPicker extends Component {
     const itemStyle = this.props.itemStyle || {};
     return (
       <Modal
+        supportedOrientations={this.props.supportedOrientations}
         animationType="slide"
         transparent
         visible={this.state.modalVisible}

--- a/lib/index.js
+++ b/lib/index.js
@@ -200,6 +200,7 @@ export default class PhoneInput extends Component {
           ref={ref => {
             this.picker = ref;
           }}
+          supportedOrientations={this.props.supportedOrientations}
           selectedCountry={iso2}
           onSubmit={this.selectCountry}
           buttonColor={this.props.pickerButtonColor}


### PR DESCRIPTION
My ios app only works in landscape mode. Using the `PhoneInput` component, I get the error:

`console.error: "Modal was presented with 0x2 orientations mask but the application only supports 0x18.Add more interface orientations to your app's Info.plist to fix this.Note: This will crash in non-dev mode."`

Fixed it by adding `supportedOrientations` to its Modal component, as per https://github.com/facebook/react-native/issues/13951 .