### PR TITLE
Add autoFormat option to PhoneInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ render(){
 | onSelectCountry | function(iso2) | null | function to be invoked when country picker is selected |
 | onPressFlag | function() | null | function to be invoked when press on flag image |
 | countriesList | array | null | custom countries list |
+| autoFormat | bool | false | automatically format phone number as it is entered |
 
 ### Functions:
 | Function Name | Return Type | Parameters | Description |

--- a/lib/index.js
+++ b/lib/index.js
@@ -137,6 +137,12 @@ export default class PhoneInput extends Component {
     );
   }
 
+  format(text) {
+    return this.props.autoFormat
+      ? PhoneNumber.format(text, this.state.iso2)
+      : text;
+  }
+
   updateFlagAndFormatNumber(number, actionAfterSetState = null) {
     const { allowZeroAfterCountryCode, initialCountry } = this.props;
     let iso2 = initialCountry;
@@ -148,6 +154,10 @@ export default class PhoneInput extends Component {
         ? phoneNumber
         : this.possiblyEliminateZeroAfterCountryCode(phoneNumber);
       iso2 = PhoneNumber.getCountryCodeOfNumber(phoneNumber);
+
+      phoneNumber = this.props.autoFormat
+        ? this.format(phoneNumber)
+        : phoneNumber;
     }
     this.setState({ iso2, formattedNumber: phoneNumber }, actionAfterSetState);
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -154,12 +154,8 @@ export default class PhoneInput extends Component {
         ? phoneNumber
         : this.possiblyEliminateZeroAfterCountryCode(phoneNumber);
       iso2 = PhoneNumber.getCountryCodeOfNumber(phoneNumber);
-
-      phoneNumber = this.props.autoFormat
-        ? this.format(phoneNumber)
-        : phoneNumber;
     }
-    this.setState({ iso2, formattedNumber: phoneNumber }, actionAfterSetState);
+    this.setState({ iso2, formattedNumber: this.format(phoneNumber) }, actionAfterSetState);
   }
 
   possiblyEliminateZeroAfterCountryCode(number) {

--- a/lib/phoneNumber.js
+++ b/lib/phoneNumber.js
@@ -3,7 +3,9 @@ import _ from 'lodash';
 import Country from './country';
 import numberType from './resources/numberType.json';
 
-const phoneUtil = require('google-libphonenumber').PhoneNumberUtil.getInstance();
+const libPhoneNumber = require('google-libphonenumber');
+const phoneUtil = libPhoneNumber.PhoneNumberUtil.getInstance();
+const asYouTypeFormatter = libPhoneNumber.AsYouTypeFormatter;
 
 let instance = null;
 
@@ -84,6 +86,18 @@ class PhoneNumber {
     }
 
     return false;
+  }
+
+  format(number, iso2) {
+    const formatter = new asYouTypeFormatter(iso2)
+    let formatted;
+
+    number.replace(/-/g, '')
+      .replace(/ /g, '')
+      .split('')
+      .forEach(n => formatted = formatter.inputDigit(n));
+
+    return formatted;
   }
 
   getNumberType(number, iso2) {


### PR DESCRIPTION
Adds an 'autoFormat' option to PhoneInput which allows phone numbers to be formatted as they are entered.

#
|Before|After|
|-------|-----|
|![before](https://user-images.githubusercontent.com/5092953/46460436-469bbe80-c7ff-11e8-89a7-729b0162c4e1.gif)|![after](https://user-images.githubusercontent.com/5092953/46460445-4e5b6300-c7ff-11e8-9c9d-e42c16eb8837.gif)|