### PR TITLE
Remove invalid input console log message on every text change event.

### DIFF
--- a/lib/phoneNumber.js
+++ b/lib/phoneNumber.js
@@ -71,7 +71,6 @@ class PhoneNumber {
     try {
       return phoneUtil.parse(number, iso2);
     } catch (err) {
-      console.log(`Exception was thrown: ${err.toString()}`);
       return null;
     }
   }


### PR DESCRIPTION
The following error message is displayed in the console - 
`Exception was thrown: Error: The string supplied did not seem to be a phone number.`
This message is shown right from the first few keystrokes and bloats the console with one line of log per character typed.

