### PR TITLE
Fixed Kazakhstan prefix in countries.json

### DIFF
--- a/lib/resources/countries.json
+++ b/lib/resources/countries.json
@@ -812,7 +812,7 @@
   {
     "name": "Kazakhstan (Казахстан)",
     "iso2": "kz",
-    "dialCode": "7",
+    "dialCode": "77",
     "priority": 1,
     "areaCodes": null
   },


### PR DESCRIPTION
Correctly property "dialCode" for Kazakhstan = "77".