### PR TITLE
Allow local numbers in addition to numbers including area code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -148,10 +148,10 @@ export default class PhoneInput extends Component {
 
   updateFlagAndFormatNumber(number, actionAfterSetState = null) {
     const { allowZeroAfterCountryCode, initialCountry } = this.props;
-    let iso2 = initialCountry;
+    let iso2 = this.getISOCode() || initialCountry;
     let formattedPhoneNumber = number;
-    let countryCode = this.getCountryCode();
     if (number) {
+      const countryCode = this.getCountryCode();
       if (formattedPhoneNumber[0] !== "+" && countryCode !== null) {
         formattedPhoneNumber = '+' + countryCode.toString() + formattedPhoneNumber.toString();
       }
@@ -159,8 +159,8 @@ export default class PhoneInput extends Component {
         ? formattedPhoneNumber
         : this.possiblyEliminateZeroAfterCountryCode(formattedPhoneNumber);
       iso2 = PhoneNumber.getCountryCodeOfNumber(formattedPhoneNumber);
-      this.setState({ iso2, formattedNumber: formattedPhoneNumber, inputValue: number }, actionAfterSetState);
     }
+    this.setState({ iso2, formattedNumber: formattedPhoneNumber, inputValue: number }, actionAfterSetState);
   }
 
   possiblyEliminateZeroAfterCountryCode(number) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -151,7 +151,6 @@ export default class PhoneInput extends Component {
     let iso2 = initialCountry;
     let formattedPhoneNumber = number;
     let countryCode = this.getCountryCode();
-
     if (number) {
       if (formattedPhoneNumber[0] !== "+" && countryCode !== null) {
         formattedPhoneNumber = '+' + countryCode.toString() + formattedPhoneNumber.toString();
@@ -160,8 +159,8 @@ export default class PhoneInput extends Component {
         ? formattedPhoneNumber
         : this.possiblyEliminateZeroAfterCountryCode(formattedPhoneNumber);
       iso2 = PhoneNumber.getCountryCodeOfNumber(formattedPhoneNumber);
+      this.setState({ iso2, formattedNumber: formattedPhoneNumber, inputValue: number }, actionAfterSetState);
     }
-    this.setState({ iso2, formattedNumber: formattedPhoneNumber, inputValue: number }, actionAfterSetState);
   }
 
   possiblyEliminateZeroAfterCountryCode(number) {
@@ -180,7 +179,7 @@ export default class PhoneInput extends Component {
   }
 
   render() {
-    const { iso2, formattedNumber, inputValue, disabled } = this.state;
+    const { iso2, inputValue, disabled } = this.state;
     const TextComponent = this.props.textComponent || TextInput;
     return (
       <View style={[styles.container, this.props.style]}>

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,8 @@ export default class PhoneInput extends Component {
       iso2: initialCountry,
       disabled,
       formattedNumber: countryData ? `+${countryData.dialCode}` : "",
-      value: null
+      value: null,
+      inputValue: "",
     };
   }
 
@@ -83,7 +84,7 @@ export default class PhoneInput extends Component {
 
   getCountryCode() {
     const countryData = PhoneNumber.getCountryDataByCode(this.state.iso2);
-    return countryData.dialCode;
+    return countryData ? countryData.dialCode : null;
   }
 
   getAllCountries() {
@@ -99,7 +100,7 @@ export default class PhoneInput extends Component {
   }
 
   getValue() {
-    return this.state.formattedNumber;
+    return this.state.formattedNumber.replace(/\s/g,'');
   }
 
   getNumberType() {
@@ -123,6 +124,7 @@ export default class PhoneInput extends Component {
             formattedNumber: `+${countryData.dialCode}`
           },
           () => {
+            this.updateFlagAndFormatNumber(this.state.inputValue)
             if (this.props.onSelectCountry) this.props.onSelectCountry(iso2);
           }
         );
@@ -131,6 +133,7 @@ export default class PhoneInput extends Component {
   }
 
   isValidNumber() {
+    if (this.state.inputValue.length < 3) return false;
     return PhoneNumber.isValidNumber(
       this.state.formattedNumber,
       this.state.iso2
@@ -146,16 +149,19 @@ export default class PhoneInput extends Component {
   updateFlagAndFormatNumber(number, actionAfterSetState = null) {
     const { allowZeroAfterCountryCode, initialCountry } = this.props;
     let iso2 = initialCountry;
-    let phoneNumber = number;
+    let formattedPhoneNumber = number;
+    let countryCode = this.getCountryCode();
 
     if (number) {
-      if (phoneNumber[0] !== "+") phoneNumber = `+${phoneNumber}`;
-      phoneNumber = allowZeroAfterCountryCode
-        ? phoneNumber
-        : this.possiblyEliminateZeroAfterCountryCode(phoneNumber);
-      iso2 = PhoneNumber.getCountryCodeOfNumber(phoneNumber);
+      if (formattedPhoneNumber[0] !== "+" && countryCode !== null) {
+        formattedPhoneNumber = '+' + countryCode.toString() + formattedPhoneNumber.toString();
+      }
+      formattedPhoneNumber = allowZeroAfterCountryCode
+        ? formattedPhoneNumber
+        : this.possiblyEliminateZeroAfterCountryCode(formattedPhoneNumber);
+      iso2 = PhoneNumber.getCountryCodeOfNumber(formattedPhoneNumber);
     }
-    this.setState({ iso2, formattedNumber: this.format(phoneNumber) }, actionAfterSetState);
+    this.setState({ iso2, formattedNumber: formattedPhoneNumber, inputValue: number }, actionAfterSetState);
   }
 
   possiblyEliminateZeroAfterCountryCode(number) {
@@ -174,7 +180,7 @@ export default class PhoneInput extends Component {
   }
 
   render() {
-    const { iso2, formattedNumber, disabled } = this.state;
+    const { iso2, formattedNumber, inputValue, disabled } = this.state;
     const TextComponent = this.props.textComponent || TextInput;
     return (
       <View style={[styles.container, this.props.style]}>
@@ -201,7 +207,7 @@ export default class PhoneInput extends Component {
             }}
             keyboardType="phone-pad"
             underlineColorAndroid="rgba(0,0,0,0)"
-            value={formattedNumber}
+            value={inputValue}
             {...this.props.textProps}
           />
         </View>


### PR DESCRIPTION
This allows using local numbers like 0444444444 in addition to long numbers like +61444444444 when flag is set.

These changes have been longly tested tested in my prod app since a long time and is working smoothly.